### PR TITLE
fix: players not being able to progress past intermission menu

### DIFF
--- a/scenes/ui/menus/pause_menu.tscn
+++ b/scenes/ui/menus/pause_menu.tscn
@@ -245,6 +245,6 @@ autostart = true
 [connection signal="pressed" from="QuitConfirmation/VBoxContainer/HBoxContainer/quit_confirm" to="." method="_on_quit_confirm_pressed"]
 [connection signal="pressed" from="QuitConfirmation/VBoxContainer/HBoxContainer/quit_cancel" to="." method="_on_quit_cancel_pressed"]
 [connection signal="pressed" from="GameOver/VBoxContainer/ButtonsContainer/submit_score_button" to="." method="_on_submit_score_button_pressed"]
-[connection signal="pressed" from="GameOver/VBoxContainer/ButtonsContainer/retry_button" to="." method="_on_revive_button_pressed"]
 [connection signal="pressed" from="GameOver/VBoxContainer/ButtonsContainer/retry_button" to="." method="_on_retry_button_pressed"]
+[connection signal="pressed" from="GameOver/VBoxContainer/ButtonsContainer/retry_button" to="." method="_on_revive_button_pressed"]
 [connection signal="pressed" from="GameOver/VBoxContainer/ButtonsContainer/main_menu_button" to="." method="_on_main_menu_button_pressed"]

--- a/scripts/intermission_menu.gd
+++ b/scripts/intermission_menu.gd
@@ -7,6 +7,10 @@ extends Control
 @onready var score_label: Label = $Panel/ScoreLabel
 @onready var level_label: Label = $Panel/LevelLabel
 
+#Scene references
+const LEVEL0 = "uid://bajvfne4dc6aj"
+const SHOP = "uid://bgwcvvk1ql283"
+
 
 
 func _ready() -> void:
@@ -17,8 +21,9 @@ func _ready() -> void:
 
 
 func _on_continue_button_pressed() -> void:
-	get_tree().change_scene_to_file("res://Level0.tscn")
+	
+	get_tree().change_scene_to_file(LEVEL0)
 
 
 func _on_shop_button_pressed() -> void:
-	get_tree().change_scene_to_file("res://scenes/shop.tscn")
+	get_tree().change_scene_to_file(SHOP)


### PR DESCRIPTION
Appeared to be caused by a improper reference to level0.tscn. Fixed by updated references with UIDs.