### PR TITLE
fix: players behind able to shoot with shield active

### DIFF
--- a/2_ndchill_wizard.gd
+++ b/2_ndchill_wizard.gd
@@ -30,7 +30,7 @@ var is_speedup_active = false
 var buff_charages = GameManager.power_ups["Attack_up"]
 var is_buff_active = false
 var DEBUG = GameManager.DEBUGMODE #TURN OFF WHEN TURNING IN
-
+var is_able_to_shoot = true
 func get_input():
 	var input_direction = Input.get_action_strength("p2_move_right") - Input.get_action_strength("p2_move_left") #left and Right movement
 	velocity = Vector2(input_direction * speed,0)  # no vert movement
@@ -64,34 +64,36 @@ func shoot():
 	#health_manager(-1)
 
 
-
-	if timer.is_stopped():
-		shots_left = GameManager.shots_left_for_each
-		timer.start()
-		if current_projectile == false: #projectile 1
-			var bullet = projectile.instantiate()
-			bullet.global_position = marker_2d.global_position
-			bullet.rotation = global_rotation
-			player_bullets.add_child(bullet)
-			bullet_sound_effect_player.stream = shoot_effect_one
-			bullet_sound_effect_player.play()
-		elif current_projectile == true: #projectile 2
-			if shots_left <= 0:
-				return
-			else:
-				shots_left = shots_left - 1
-				GameManager.shots_left_for_each = shots_left
-				GAME_HUD.update_bullets(shots_left)
-			print(str(shots_left))
-
-			var bullet = projectile_2.instantiate()
-			bullet.global_position = marker_2d.global_position
-			bullet.rotation = global_rotation
-			player_bullets.add_child(bullet)
-			bullet_sound_effect_player.stream = shoot_effect_one
-			bullet_sound_effect_player.play()
+	if is_able_to_shoot == false:
+		return
 	else:
-		pass
+		if timer.is_stopped():
+			shots_left = GameManager.shots_left_for_each
+			timer.start()
+			if current_projectile == false: #projectile 1
+				var bullet = projectile.instantiate()
+				bullet.global_position = marker_2d.global_position
+				bullet.rotation = global_rotation
+				player_bullets.add_child(bullet)
+				bullet_sound_effect_player.stream = shoot_effect_one
+				bullet_sound_effect_player.play()
+			elif current_projectile == true: #projectile 2
+				if shots_left <= 0:
+					return
+				else:
+					shots_left = shots_left - 1
+					GameManager.shots_left_for_each = shots_left
+					GAME_HUD.update_bullets(shots_left)
+				print(str(shots_left))
+
+				var bullet = projectile_2.instantiate()
+				bullet.global_position = marker_2d.global_position
+				bullet.rotation = global_rotation
+				player_bullets.add_child(bullet)
+				bullet_sound_effect_player.stream = shoot_effect_one
+				bullet_sound_effect_player.play()
+		else:
+			pass
 
 func health_manager(change: int):
 	health = GameManager.power_ups["Health_up"]  # Get current health from GameManager
@@ -161,3 +163,7 @@ func speed_up():
 			await get_tree().create_timer(10.00).timeout
 			speed = speed / 2
 			is_speedup_active = false
+
+
+func _on_sheld_shield_active(active: bool) -> void:
+	is_able_to_shoot = active

--- a/character_body_2d.gd
+++ b/character_body_2d.gd
@@ -1,39 +1,74 @@
 extends CharacterBody2D
 class_name sheld
+#Signals
+signal shield_active(active: bool)
+
+
+#Node references
 
 @export var speed = 400
 @onready var timer = $Timer
 @onready var fading_out = false
-var fade_speed = 0.01
+@onready var chill_wizard = preload("uid://bm34pb8r8frsm")
+@onready var _2_ndchill_wizard = preload("uid://b5ygvkf7gbnyh")
+
+
+var sheild_up = false
+var fade_speed = 0.1
+var sheild_used = false
+@onready var parent
+
+
 func _ready() -> void:
 	visible = false
 func _physics_process(delta: float) -> void:
 	
 	
+	
 	if get_parent().name == "ChillWizard":
+		parent = chill_wizard
 		visible = Input.is_action_pressed("p1_shield")
 		if Input.is_action_just_pressed("p1_shield"):
+			if sheild_used:
+				return
 			fading_out = true
+			sheild_up = true
+			emit_signal("shield_active", !sheild_up)
 		if Input.is_action_just_released("p1_shield"):
 			fading_out = false
+			sheild_up = false
+			emit_signal("shield_active", !sheild_up)
+			#parent.is_able_to_shoot = not sheild_up
 		if visible :
 				if fading_out and modulate.a > 0:
 					modulate.a -= fade_speed * delta
 					if modulate.a <= 0:
+						sheild_used = true
+						emit_signal("shield_active",true )
 						visible = false
 						fading_out = false
 	elif get_parent().name == "2ndchill_wizard":
+		parent = _2_ndchill_wizard
 		visible = Input.is_action_pressed("p2_shield")
 		if Input.is_action_just_pressed("p2_shield"):
+			if sheild_used:
+				return
 			fading_out = true
+			sheild_up = true
+			emit_signal("shield_active", !sheild_up)
 		if Input.is_action_just_released("p2_shield"):
+			sheild_up = false
 			fading_out = false
+			emit_signal("shield_active", !sheild_up)
 		if visible :
 				if fading_out and modulate.a > 0:
 					modulate.a -= fade_speed * delta
 					if modulate.a <= 0:
+						sheild_used = true
+						emit_signal("shield_active",true )
 						visible = false
 						fading_out = false
+	
 	"""
 	visible = Input.is_action_pressed("p1_shield")
 	if Input.is_action_just_pressed("p1_shield"):
@@ -52,6 +87,7 @@ func _on_area_2d_area_entered(area: Area2D) -> void:
 		if modulate.a >= 0:
 			if area.is_in_group("enemy_attacks"):
 				area.queue_free()
+				modulate.a = modulate.a / 2
 		else:
 			pass
  # Replace with function body.

--- a/scenes/Characters/chill_wizard.gd
+++ b/scenes/Characters/chill_wizard.gd
@@ -1,34 +1,33 @@
 extends CharacterBody2D
 class_name player
+#Signals
+signal player_died
 
-@export var speed = 400
-@onready var main = get_tree().get_root()
-
-@export var projectile : PackedScene
-@export var projectile_2 : PackedScene
-var current_projectile = false #false for projectile 1, true for projectile 2
-
-@onready var marker_2d: Marker2D = $Marker2D
-
+#Node References
 @onready var GAME_HUD = $"../../game_hud"
 @onready var animation_player: AnimationPlayer = $AnimationPlayer
 @onready var bullet_sound_effect_player: AudioStreamPlayer = $BulletSoundEffectPlayer
 @onready var player_bullets: Node2D = $"../../BulletManager/PlayerBullets"
-
 @onready var timer: Timer = $Timer
+@onready var main = get_tree().get_root()
+@onready var marker_2d: Marker2D = $Marker2D
 
-signal player_died
+#Exports
+@export var speed = 400
+@export var projectile : PackedScene
+@export var projectile_2 : PackedScene
+
+#Variables
+var current_projectile = false #false for projectile 1, true for projectile 2
 var shots_left = 3
 var shoot_effect_one = preload("uid://lq088uvjrlrj")
-
 var rapid = false
 var health = GameManager.power_ups["Health_up"]
-
 var speedup_charges = GameManager.power_ups["Dash"]
 var is_speedup_active = false
-
 var buff_charages = GameManager.power_ups["Attack_up"]
 var is_buff_active = false
+var is_able_to_shoot = true
 var DEBUG = GameManager.DEBUGMODE #TURN OFF WHEN TURNING IN
 
 func get_input():
@@ -68,35 +67,37 @@ func shoot():
 	#health_manager(-1)
 
 
-
-	if timer.is_stopped():
-		shots_left = GameManager.shots_left_for_each
-		GAME_HUD.update_bullets(shots_left, current_projectile)
-		timer.start()
-		if current_projectile == false: #projectile 1
-			var bullet = projectile.instantiate()
-			bullet.global_position = marker_2d.global_position
-			bullet.rotation = global_rotation
-			player_bullets.add_child(bullet)
-			bullet_sound_effect_player.stream = shoot_effect_one
-			bullet_sound_effect_player.play()
-		elif current_projectile == true: #projectile 2
-			if shots_left <= 0:
-				return
-			else:
-				shots_left = shots_left - 1
-				GameManager.shots_left_for_each = shots_left
-				GAME_HUD.update_bullets(shots_left, current_projectile)
-			print(str(shots_left))
-
-			var bullet = projectile_2.instantiate()
-			bullet.global_position = marker_2d.global_position
-			bullet.rotation = global_rotation
-			player_bullets.add_child(bullet)
-			bullet_sound_effect_player.stream = shoot_effect_one
-			bullet_sound_effect_player.play()
+	if is_able_to_shoot == false:
+		return
 	else:
-		pass
+		if timer.is_stopped():
+			shots_left = GameManager.shots_left_for_each
+			GAME_HUD.update_bullets(shots_left, current_projectile)
+			timer.start()
+			if current_projectile == false: #projectile 1
+				var bullet = projectile.instantiate()
+				bullet.global_position = marker_2d.global_position
+				bullet.rotation = global_rotation
+				player_bullets.add_child(bullet)
+				bullet_sound_effect_player.stream = shoot_effect_one
+				bullet_sound_effect_player.play()
+			elif current_projectile == true: #projectile 2
+				if shots_left <= 0:
+					return
+				else:
+					shots_left = shots_left - 1
+					GameManager.shots_left_for_each = shots_left
+					GAME_HUD.update_bullets(shots_left, current_projectile)
+				print(str(shots_left))
+
+				var bullet = projectile_2.instantiate()
+				bullet.global_position = marker_2d.global_position
+				bullet.rotation = global_rotation
+				player_bullets.add_child(bullet)
+				bullet_sound_effect_player.stream = shoot_effect_one
+				bullet_sound_effect_player.play()
+		else:
+			pass
 func health_manager(change: int):
 	health = GameManager.power_ups["Health_up"]  # Get current health from GameManager
 	health += change
@@ -164,3 +165,7 @@ func speed_up():
 			await get_tree().create_timer(10.00).timeout
 			speed = speed / 2
 			is_speedup_active = false
+
+
+func _on_sheld_shield_active(active: bool) -> void:
+	is_able_to_shoot = active

--- a/scenes/Level0.tscn
+++ b/scenes/Level0.tscn
@@ -113,3 +113,5 @@ position = Vector2(673, 256)
 [connection signal="area_entered" from="Enviroment/Walls/RightWall" to="enemy_spawner" method="_on_right_wall_area_entered"]
 [connection signal="area_entered" from="Enviroment/Walls/LeftWall" to="enemy_spawner" method="_on_left_wall_area_entered"]
 [connection signal="body_entered" from="cleanup" to="." method="_on_cleanup_body_entered"]
+[connection signal="shield_active" from="PlayerManager/ChillWizard/Sheld" to="PlayerManager/ChillWizard" method="_on_sheld_shield_active"]
+[connection signal="shield_active" from="PlayerManager/2ndchill_wizard/Sheld" to="PlayerManager/2ndchill_wizard" method="_on_sheld_shield_active"]

--- a/scenes/Player_Attack/player_attack_1.tscn
+++ b/scenes/Player_Attack/player_attack_1.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=4 format=3 uid="uid://canis8lb32gex"]
 
-[ext_resource type="Script" uid="uid://01wu4m80bjn2" path="res://resources/enemys/player_attack_1.gd" id="1_ouor6"]
+[ext_resource type="Script" path="res://resources/enemys/player_attack_1.gd" id="1_ouor6"]
 [ext_resource type="Texture2D" uid="uid://5v6o14dvhr8c" path="res://scenes/Player_Attack/Player_Attack_Sprites/Player-attack_1.png" id="2_sdg6d"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_46hnk"]


### PR DESCRIPTION
Cause: No checks in place to see if players even have shield up, and to block.
Fix: Adding mentions check statements and signals. Also made shield duration reduce if hit. Might be a bit unfair, may remove.